### PR TITLE
fix(ci): repair parse-dead workflow — K9-SVC step at job-level indent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           draft: false
           prerelease: false
 
-  - name: K9-SVC Validation
-    run: |
-      echo "K9-SVC validation"
-      [ -d .machine_readable/contractiles ] && echo "Contractiles present" || echo "No contractiles"
+      - name: K9-SVC Validation
+        run: |
+          echo "K9-SVC validation"
+          [ -d .machine_readable/contractiles ] && echo "Contractiles present" || echo "No contractiles"


### PR DESCRIPTION
## The fault

A sweep appended a `K9-SVC Validation` step at **two-space** indentation — the level of a job key under `jobs:` — instead of the six spaces that would place it inside a job's `steps:` list:

```yaml
jobs:
  dispatch:
    steps:
      - name: Confirm
        run: echo ...

  - name: K9-SVC Validation     # <-- col 2. Should be col 6.
    run: |
      ...
```

YAML hits a sequence item where it expects a block mapping, and **the whole file fails to parse**.

Actions rejects a workflow that doesn't parse *before* allocating a runner, so **this workflow has produced no check run and no log since the step was added — it has not been running at all.**

## Recognising this class

- the run is listed by **file path** instead of workflow name
- `gh run view --log-failed` returns **"log not found"**
- `gh pr checks` shows **nothing** — a parse-rejected workflow creates no check run

Only `gh run list --json conclusion` reveals it.

## The fix

Re-indent the step and its body by four spaces so it sits inside the job's `steps:` list. **Nothing else changes** — no action pins, no permissions, no logic.

Verified: the file parses, `jobs` is a non-empty mapping, and every job has `steps` or `uses`.

## Estate context

Measured 2026-07-27 across all workflow files in `hyper-repos/`, `meta-repos/` and `repos/`: this fault affects **49 files across 45 repositories, and 100% of them fail to parse** — not a sample. The 12 files where the same step *is* correctly indented are what established the intended shape.

Mostly `instant-sync.yml` (forge propagation), plus `boj-build.yml`, `casket-pages.yml`, `release.yml`, `cflite_pr.yml` and one `codeql.yml`.

A separate group of 6 `boj-build.yml` files carries additional independent faults (a `permissions:` block injected at column 0 mid-file, and a mangled curl payload) and is being repaired individually rather than by this sweep.

## Provenance

Built with git plumbing directly against `origin/HEAD`, so no local working tree was involved and **no unrelated local changes are included** — several of these repositories have sweep debris in their working copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
