### PR TITLE
fix(security): upgrade secret scanning from retired trufflehog to gitleaks

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -1,63 +1,22 @@
 # SPDX-License-Identifier: MPL-2.0
-name: Secret Scanner
+# Calls the estate's shared secret scanner (gitleaks + rust-secrets +
+# shell-secrets). Replaces an inline trufflehog job: trufflehog was retired
+# estate-wide as redundant, and this repo had no other leak scanning, so the
+# scanner is UPGRADED here rather than removed.
+#
+# `secrets: inherit` is REQUIRED — without it the gitleaks action's inner
+# secrets.GITHUB_TOKEN is empty and the scan silently degrades.
+name: 'Secret Scanner'
 on:
   pull_request:
   push:
-    branches: [main]
-# Estate guardrail: cancel superseded runs so re-pushes / rebased PR
-# updates do not pile up queued runs against the shared account-wide
-# Actions concurrency pool. Applied only to read-only check workflows
-# (no publish/mutation), so cancelling a superseded run is always safe.
+    branches: [main, master]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 permissions:
   contents: read
 jobs:
-  trufflehog:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-        with:
-          fetch-depth: 0 # Full history for scanning
-      - name: TruffleHog Secret Scan
-        uses: trufflesecurity/trufflehog@6c05c4a00b91aa542267d8e32a8254774799d68d # v3
-        with:
-          # The v3 action injects --fail automatically on pull_request events.
-          # Passing --fail here triggers "flag 'fail' cannot be repeated".
-          extra_args: --only-verified
-  # Rust-specific: Check for hardcoded crypto values
-  rust-secrets:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-      - name: Check for hardcoded secrets in Rust
-        run: |
-          if ! find . -name Cargo.toml -not -path './target/*' -print -quit | grep -q .; then
-            echo 'No Cargo.toml found — skipping Rust secrets check'
-            exit 0
-          fi
-          # Patterns that suggest hardcoded secrets
-          PATTERNS=(
-            'const.*SECRET.*=.*"'
-            'const.*KEY.*=.*"[a-zA-Z0-9]{16,}"'
-            'const.*TOKEN.*=.*"'
-            'let.*api_key.*=.*"'
-            'HMAC.*"[a-fA-F0-9]{32,}"'
-            'password.*=.*"[^"]+"'
-          )
-
-          found=0
-          for pattern in "${PATTERNS[@]}"; do
-            if grep -rn --include="*.rs" -E "$pattern" src/; then
-              echo "WARNING: Potential hardcoded secret found matching: $pattern"
-              found=1
-            fi
-          done
-
-          if [ $found -eq 1 ]; then
-            echo "::error::Potential hardcoded secrets detected. Use environment variables instead."
-            exit 1
-          fi
+  scan:
+    uses: hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@bd0df9ead7faf0cdfe0e13e7966d91e28d0101d4
+    secrets: inherit


### PR DESCRIPTION
**This repo's only leak scanning was an inline trufflehog job** — and trufflehog was retired estate-wide. The standards secret-scanner reusable records the ruling in its own header:

> *"Trufflehog was removed as redundant; gitleaks catches what we need"*
> *"Trufflehog removed: gitleaks provides sufficient coverage at lower cost."*

## This is an upgrade, not a removal — and that distinction is the point

A sweep is currently deleting leftover trufflehog steps across the estate. **This repo was deliberately excluded from it.** With no other scanner present, deleting would have left it with **no secret scanning at all**.

Estate-wide measurement, all 424 repos (364 have workflows):

| | count | treatment |
|---|---:|---|
| gitleaks only | 170 (47%) | left alone |
| trufflehog **and** gitleaks | 73 (20%) | straggler deleted |
| **trufflehog only** | **33 (9%)** | **this PR — upgraded** |
| neither | 88 (24%) | still open |

## What actually changes

- **gitleaks over the whole working tree** with `--no-git`, exiting non-zero on a finding. The inline job scanned a `base..head` diff — narrower than the tree.
- The reusable's **`rust-secrets` and `shell-secrets`** jobs come along with it, so the local `rust-secrets` grep is no longer needed separately.
- A **pinned, checksum-verified gitleaks binary** rather than an action that injects one.

## Two details that would fail silently if omitted

**`secrets: inherit` is required**, and is included. Without it the gitleaks action's inner `secrets.GITHUB_TOKEN` is empty and the scan **silently degrades** — a quiet failure of exactly the kind this campaign exists to remove.

**Where an `actions.lock` exists it gains a hand-authored `[]` entry** for this file. `gh actions-lock` **skips reusable-workflow callers**, and without the entry the workflow is rejected as `startup_failure` with no log and no check run — which reads as "the change broke CI" rather than "a lockfile entry is missing".

## No context is stranded

The workflow's `name:` is preserved verbatim. Job-level context names *do* change, since they now come from the reusable — this repo's rulesets were checked first and require no secret-scanning context, so nothing is left pointing at a string that will never report.

Found during the 2026-08-05 estate CI/CD census.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
