### PR TITLE
fix(codeql): analyse the languages this repository actually has

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - language: javascript-typescript
+          - language: actions
             build-mode: none
     steps:
       - name: Checkout


### PR DESCRIPTION
`codeql database finalize` was exiting **32** on every run:

> CodeQL could not process any code written in JavaScript/TypeScript.

The matrix asserted `javascript-typescript`; this repository's languages are `none`. One `codeql.yml` was copied estate-wide with a hard-coded JS matrix — **82 repositories** carry it, and 17 of the 18 sampled have no JavaScript at all (Julia, Rust, Zig, Agda, Ada, Haskell, Elixir).

**This is not only a failing check.** The crash uploads no SARIF, so a `code_scanning` ruleset rule requiring CodeQL waits forever on *"Code scanning is waiting for results from CodeQL"*. One fault, two symptoms — and relaxing the rule's thresholds could not have helped, because no results arrive at all.

`actions` is kept (or added): it is valid in every repository, since every repository has workflow files, and it keeps this workflow producing a check and a SARIF upload even where CodeQL can analyse nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)