### PR TITLE
ci: remove Julia 1.9 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        julia-version: ['1.9', '1.10', '1.11']
+        julia-version: ['1.10', '1.11']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2


### PR DESCRIPTION
Remove the obsolete Julia 1.9 CI matrix entry. Julia 1.10 and 1.11 remain required supported versions; nightly remains where it was already part of the matrix.