### PR TITLE
fix: AGENTIC licence line + a2ml-validate-action repin

### DIFF
--- a/.machine_readable/6a2/AGENTIC.a2ml
+++ b/.machine_readable/6a2/AGENTIC.a2ml
@@ -21,7 +21,12 @@ can-create-files = true
 # - Never commit secrets or credentials
 # - Never use banned languages (TypeScript, Python, Go, etc.)
 # - Never place state files in repository root (must be in .machine_readable/)
-# - Never use AGPL license (use MPL-2.0)
+# - Never relicense an existing file, and never run an automated licence
+#   sweep (LICENCE-POLICY.adoc A2). New files get correct SPDX from birth.
+# - Never assume a licence. Read standards/LICENCE-POLICY.adoc: Rule 1
+#   defaults to MPL-2.0 (code) / CC-BY-SA-4.0 (prose), but Rule 3
+#   (co-developed), Rule 4 (network-deployed services) and Rule 5
+#   (games) are AGPL-3.0-or-later, and Rule 2 names the PMPL register.
 
 [maintenance-integrity]
 fail-closed = true


### PR DESCRIPTION
Ruleset refused a direct push, so this lands by PR. Two mechanical fixes, owner-ruled:

1. **AGENTIC licence line** — `Never use AGPL license (…)` contradicts `LICENCE-POLICY.adoc` Rules 3/4/5 (which mandate AGPL for their scopes). Replaced with the policy pointer used in `rsr-template-repo#45`. See `standards#646`.
2. **`a2ml-validate-action` repin** — the previously-pinned SHAs never existed; the repo was only created 2026-08-28 (split from `a2ml/actions/validate`, history preserved). Repinned to its real HEAD. See `standards#669`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
